### PR TITLE
Changed Kanji PK to Compound + grouped loose constants into classes

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -34,31 +34,34 @@ class CustomDatabase {
         await _onUpgrade(db, oldVersion, newVersion);
       },
       onCreate: (Database db, int version) async {
-        await db.execute("CREATE TABLE $kanjiTable("
-            "$kanjiField TEXT PRIMARY KEY NOT NULL, "
-            "$listNameField TEXT NOT NULL, "
-            "$meaningField TEXT NOT NULL, "
-            "$pronunciationField TEXT NOT NULL, "
-            "$winRateWritingField INTEGER NOT NULL DEFAULT -1, "
-            "$winRateReadingField INTEGER NOT NULL DEFAULT -1, "
-            "$winRateRecognitionField INTEGER NOT NULL DEFAULT -1, "
-            "$dateAddedField INTEGER NOT NULL DEFAULT 0, "
-            "FOREIGN KEY ($listNameField) REFERENCES $listsTable($nameField) ON DELETE CASCADE ON UPDATE CASCADE)");
+        await db.execute("CREATE TABLE ${KanjiTableFields.kanjiTable}("
+            "${KanjiTableFields.kanjiField} TEXT NOT NULL, "
+            "${KanjiTableFields.listNameField} TEXT NOT NULL, "
+            "${KanjiTableFields.meaningField} TEXT NOT NULL, "
+            "${KanjiTableFields.pronunciationField} TEXT NOT NULL, "
+            "${KanjiTableFields.winRateWritingField} INTEGER NOT NULL DEFAULT -1, "
+            "${KanjiTableFields.winRateReadingField} INTEGER NOT NULL DEFAULT -1, "
+            "${KanjiTableFields.winRateRecognitionField} INTEGER NOT NULL DEFAULT -1, "
+            "${KanjiTableFields.dateAddedField} INTEGER NOT NULL DEFAULT 0, "
+            "PRIMARY KEY (${KanjiTableFields.kanjiField}, ${KanjiTableFields.meaningField}, ${KanjiTableFields.pronunciationField}), "
+            "FOREIGN KEY (${KanjiTableFields.listNameField}) "
+            "REFERENCES ${KanListTableFields.listsTable}(${KanListTableFields.nameField}) "
+            "ON DELETE CASCADE ON UPDATE CASCADE)");
 
-        await db.execute("CREATE TABLE $listsTable("
-            "$nameField TEXT PRIMARY KEY NOT NULL, "
-            "$totalWinRateWritingField INTEGER NOT NULL DEFAULT -1, "
-            "$totalWinRateReadingField INTEGER NOT NULL DEFAULT -1, "
-            "$totalWinRateRecognitionField INTEGER NOT NULL DEFAULT -1, "
-            "$lastUpdatedField INTEGER NOT NULL DEFAULT 0)");
+        await db.execute("CREATE TABLE ${KanListTableFields.listsTable}("
+            "${KanListTableFields.nameField} TEXT PRIMARY KEY NOT NULL, "
+            "${KanListTableFields.totalWinRateWritingField} INTEGER NOT NULL DEFAULT -1, "
+            "${KanListTableFields.totalWinRateReadingField} INTEGER NOT NULL DEFAULT -1, "
+            "${KanListTableFields.totalWinRateRecognitionField} INTEGER NOT NULL DEFAULT -1, "
+            "${KanListTableFields.lastUpdatedField} INTEGER NOT NULL DEFAULT 0)");
 
-        await db.execute("CREATE TABLE $testTable("
-            "$testIdField INTEGER PRIMARY KEY AUTOINCREMENT, "
-            "$takenDateField INTEGER NOT NULL DEFAULT 0, "
-            "$testScoreField INTEGER NOT NULL DEFAULT 0, "
-            "$kanjiInTestField INTEGER NOT NULL DEFAULT 0, "
-            "$kanjiListsField TEXT NOT NULL, "
-            "$studyModeField INTEGER NOT NULL DEFAULT 0)");
+        await db.execute("CREATE TABLE ${TestTableFields.testTable}("
+            "${TestTableFields.testIdField} INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "${TestTableFields.takenDateField} INTEGER NOT NULL DEFAULT 0, "
+            "${TestTableFields.testScoreField} INTEGER NOT NULL DEFAULT 0, "
+            "${TestTableFields.kanjiInTestField} INTEGER NOT NULL DEFAULT 0, "
+            "${TestTableFields.kanjiListsField} TEXT NOT NULL, "
+            "${TestTableFields.studyModeField} INTEGER NOT NULL DEFAULT 0)");
       });
   }
 

--- a/lib/core/database/database_consts.dart
+++ b/lib/core/database/database_consts.dart
@@ -1,24 +1,30 @@
-const String kanjiTable = "KANJI_TABLE";
-const String kanjiField = "kanji";
-const String listNameField = "name";
-const String meaningField = "meaning";
-const String pronunciationField = "pronunciation";
-const String winRateWritingField = "winRateWriting";
-const String winRateReadingField = "winRateReading";
-const String winRateRecognitionField = "winRateRecognition";
-const String dateAddedField = "dateAdded";
+class KanjiTableFields {
+  static const String kanjiTable = "KANJI_TABLE";
+  static const String kanjiField = "kanji";
+  static const String listNameField = "name";
+  static const String meaningField = "meaning";
+  static const String pronunciationField = "pronunciation";
+  static const String winRateWritingField = "winRateWriting";
+  static const String winRateReadingField = "winRateReading";
+  static const String winRateRecognitionField = "winRateRecognition";
+  static const String dateAddedField = "dateAdded";
+}
 
-const String listsTable = "LISTS_TABLE";
-const String nameField = "name";
-const String totalWinRateWritingField = "totalWinRateWriting";
-const String totalWinRateReadingField = "totalWinRateReading";
-const String totalWinRateRecognitionField = "totalWinRateRecognition";
-const String lastUpdatedField = "lastUpdated";
+class KanListTableFields {
+  static const String listsTable = "LISTS_TABLE";
+  static const String nameField = "name";
+  static const String totalWinRateWritingField = "totalWinRateWriting";
+  static const String totalWinRateReadingField = "totalWinRateReading";
+  static const String totalWinRateRecognitionField = "totalWinRateRecognition";
+  static const String lastUpdatedField = "lastUpdated";
+}
 
-const String testTable = "TEST_RESULT_TABLE";
-const String testIdField = "id";
-const String takenDateField = "takenDate";
-const String testScoreField = "score";
-const String kanjiInTestField = "totalKanji";
-const String kanjiListsField = "kanjiLists";
-const String studyModeField = "studyMode";
+class TestTableFields {
+  static const String testTable = "TEST_RESULT_TABLE";
+  static const String testIdField = "id";
+  static const String takenDateField = "takenDate";
+  static const String testScoreField = "score";
+  static const String kanjiInTestField = "totalKanji";
+  static const String kanjiListsField = "kanjiLists";
+  static const String studyModeField = "studyMode";
+}

--- a/lib/core/database/models/kanji.dart
+++ b/lib/core/database/models/kanji.dart
@@ -5,21 +5,21 @@ part 'kanji.g.dart';
 
 @JsonSerializable()
 class Kanji {
-  @JsonKey(name: kanjiField)
+  @JsonKey(name: KanjiTableFields.kanjiField)
   final String kanji;
-  @JsonKey(name: listNameField)
+  @JsonKey(name: KanjiTableFields.listNameField)
   final String listName;
-  @JsonKey(name: meaningField)
+  @JsonKey(name: KanjiTableFields.meaningField)
   final String meaning;
-  @JsonKey(name: pronunciationField)
+  @JsonKey(name: KanjiTableFields.pronunciationField)
   final String pronunciation;
-  @JsonKey(name: winRateWritingField)
+  @JsonKey(name: KanjiTableFields.winRateWritingField)
   final double winRateWriting;
-  @JsonKey(name: winRateReadingField)
+  @JsonKey(name: KanjiTableFields.winRateReadingField)
   final double winRateReading;
-  @JsonKey(name: winRateRecognitionField)
+  @JsonKey(name: KanjiTableFields.winRateRecognitionField)
   final double winRateRecognition;
-  @JsonKey(name: dateAddedField)
+  @JsonKey(name: KanjiTableFields.dateAddedField)
   final int dateAdded;
 
   const Kanji({required this.kanji, required this.listName, required this.meaning,

--- a/lib/core/database/models/list.dart
+++ b/lib/core/database/models/list.dart
@@ -5,15 +5,15 @@ part 'list.g.dart';
 
 @JsonSerializable()
 class KanjiList {
-  @JsonKey(name: nameField)
+  @JsonKey(name: KanListTableFields.nameField)
   final String name;
-  @JsonKey(name: totalWinRateWritingField)
+  @JsonKey(name: KanListTableFields.totalWinRateWritingField)
   double totalWinRateWriting;
-  @JsonKey(name: totalWinRateReadingField)
+  @JsonKey(name: KanListTableFields.totalWinRateReadingField)
   double totalWinRateReading;
-  @JsonKey(name: totalWinRateRecognitionField)
+  @JsonKey(name: KanListTableFields.totalWinRateRecognitionField)
   double totalWinRateRecognition;
-  @JsonKey(name: lastUpdatedField)
+  @JsonKey(name: KanListTableFields.lastUpdatedField)
   final int lastUpdated;
 
   KanjiList({required this.name, this.totalWinRateWriting = -1, this.totalWinRateReading = -1,

--- a/lib/core/database/models/test_result.dart
+++ b/lib/core/database/models/test_result.dart
@@ -5,15 +5,15 @@ part 'test_result.g.dart';
 
 @JsonSerializable()
 class Test {
-  @JsonKey(name: takenDateField)
+  @JsonKey(name: TestTableFields.takenDateField)
   final int takenDate;
-  @JsonKey(name: testScoreField)
+  @JsonKey(name: TestTableFields.testScoreField)
   final double testScore;
-  @JsonKey(name: kanjiInTestField)
+  @JsonKey(name: TestTableFields.kanjiInTestField)
   final int kanjiInTest;
-  @JsonKey(name: kanjiListsField)
+  @JsonKey(name: TestTableFields.kanjiListsField)
   final String kanjiLists;
-  @JsonKey(name: studyModeField)
+  @JsonKey(name: TestTableFields.studyModeField)
   final int studyMode;
 
   Test({required this.takenDate, required this.testScore, required this.kanjiLists,

--- a/lib/core/database/queries/back_up_queries.dart
+++ b/lib/core/database/queries/back_up_queries.dart
@@ -22,10 +22,10 @@ class BackUpQueries {
         /// Conflict algorithm allows us to merge the data from back up with current one.
         final batch = _database?.batch();
         for (int x = 0; x < lists.length; x++) {
-          batch?.insert(listsTable, lists[x].toJson(), conflictAlgorithm: ConflictAlgorithm.ignore);
+          batch?.insert(KanListTableFields.listsTable, lists[x].toJson(), conflictAlgorithm: ConflictAlgorithm.ignore);
         }
         for (int x = 0; x < kanji.length; x++) {
-          batch?.insert(kanjiTable, kanji[x].toJson(), conflictAlgorithm: ConflictAlgorithm.ignore);
+          batch?.insert(KanjiTableFields.kanjiTable, kanji[x].toJson(), conflictAlgorithm: ConflictAlgorithm.ignore);
         }
         final results = await batch?.commit();
         return results?.length == 0 ? "backup_queries_mergeBackUp_failed".tr() : "";

--- a/lib/core/database/queries/kanji_queries.dart
+++ b/lib/core/database/queries/kanji_queries.dart
@@ -22,7 +22,7 @@ class KanjiQueries {
   Future<int> createKanji(Kanji kanji) async {
     if (_database != null) {
       try {
-        await _database?.insert(kanjiTable, kanji.toJson());
+        await _database?.insert(KanjiTableFields.kanjiTable, kanji.toJson());
         return 0;
       } catch (err) {
         print(err.toString());
@@ -37,7 +37,7 @@ class KanjiQueries {
     if (_database != null) {
       try {
         List<Map<String, dynamic>>? res = [];
-        res = await _database?.query(kanjiTable);
+        res = await _database?.query(KanjiTableFields.kanjiTable);
         if (res != null) return List.generate(res.length, (i) => Kanji.fromJson(res![i]));
         else return [];
       } catch (err) {
@@ -55,12 +55,12 @@ class KanjiQueries {
       try {
         String whereClause = "";
         /// Build up the where clauses from the listName
-        listNames.forEach((name) => whereClause += "$listNameField=? OR ");
+        listNames.forEach((name) => whereClause += "${KanjiTableFields.listNameField}=? OR ");
         /// Clean up the String
         whereClause = whereClause.substring(0, whereClause.length - 4);
         List<Map<String, dynamic>>? res = [];
 
-        res = await _database?.query(kanjiTable, where: whereClause, whereArgs: listNames);
+        res = await _database?.query(KanjiTableFields.kanjiTable, where: whereClause, whereArgs: listNames);
         if (res != null) return List.generate(res.length, (i) => Kanji.fromJson(res![i]));
         else return [];
       } catch (err) {
@@ -76,7 +76,9 @@ class KanjiQueries {
     if (_database != null) {
       try {
         List<Map<String, dynamic>>? res = [];
-        res = await _database?.query(kanjiTable, where: "$listNameField=?", whereArgs: [listName], orderBy: "$dateAddedField ASC");
+        res = await _database?.query(KanjiTableFields.kanjiTable,
+            where: "${KanjiTableFields.listNameField}=?", whereArgs: [listName],
+            orderBy: "${KanjiTableFields.dateAddedField} ASC");
         if (res != null) return List.generate(res.length, (i) => Kanji.fromJson(res![i]));
         else return [];
       } catch (err) {
@@ -95,16 +97,16 @@ class KanjiQueries {
         List<Map<String, dynamic>>? res = [];
         switch (mode) {
           case StudyModes.writing:
-            res = await _database?.query(kanjiTable, where: "$listNameField=?",
-                whereArgs: [listName], orderBy: "$winRateWritingField ASC");
+            res = await _database?.query(KanjiTableFields.kanjiTable, where: "${KanjiTableFields.listNameField}=?",
+                whereArgs: [listName], orderBy: "${KanjiTableFields.winRateWritingField} ASC");
             break;
           case StudyModes.reading:
-            res = await _database?.query(kanjiTable, where: "$listNameField=?",
-                whereArgs: [listName], orderBy: "$winRateReadingField ASC");
+            res = await _database?.query(KanjiTableFields.kanjiTable, where: "${KanjiTableFields.listNameField}=?",
+                whereArgs: [listName], orderBy: "${KanjiTableFields.winRateReadingField} ASC");
             break;
           case StudyModes.recognition:
-            res = await _database?.query(kanjiTable, where: "$listNameField=?",
-                whereArgs: [listName], orderBy: "$winRateRecognitionField ASC");
+            res = await _database?.query(KanjiTableFields.kanjiTable, where: "${KanjiTableFields.listNameField}=?",
+                whereArgs: [listName], orderBy: "${KanjiTableFields.winRateRecognitionField} ASC");
             break;
         }
         if (res != null) return List.generate(res.length, (i) => Kanji.fromJson(res![i]));
@@ -122,7 +124,9 @@ class KanjiQueries {
     if (_database != null) {
       try {
         List<Map<String, dynamic>>? res = [];
-        res = await _database?.query(kanjiTable, where: "$listNameField=? AND $kanjiField=?", whereArgs: [listName, kanji]);
+        res = await _database?.query(KanjiTableFields.kanjiTable,
+            where: "${KanjiTableFields.listNameField}=? AND ${KanjiTableFields.kanjiField}=?",
+            whereArgs: [listName, kanji]);
         if (res != null) return Kanji.fromJson(res[0]);
         else return Kanji.empty;
       } catch (err) {
@@ -143,7 +147,9 @@ class KanjiQueries {
   Future<int> removeKanji(String listName, String kanji) async {
     if (_database != null) {
       try {
-        await _database?.delete(kanjiTable, where: "$listNameField=? AND $kanjiField=?", whereArgs: [listName, kanji]);
+        await _database?.delete(KanjiTableFields.kanjiTable,
+            where: "${KanjiTableFields.listNameField}=? AND ${KanjiTableFields.kanjiField}=?",
+            whereArgs: [listName, kanji]);
         return 0;
       } catch (err) {
         print(err.toString());
@@ -163,7 +169,9 @@ class KanjiQueries {
   Future<int> updateKanji(String listName, String kanji, Map<String, dynamic> fields) async {
     if (_database != null) {
       try {
-        await _database?.update(kanjiTable, fields, where: "$listNameField=? AND $kanjiField=?", whereArgs: [listName, kanji]);
+        await _database?.update(KanjiTableFields.kanjiTable, fields,
+            where: "${KanjiTableFields.listNameField}=? AND ${KanjiTableFields.kanjiField}=?",
+            whereArgs: [listName, kanji]);
         return 0;
       } catch (err) {
         print(err.toString());

--- a/lib/core/database/queries/list_queries.dart
+++ b/lib/core/database/queries/list_queries.dart
@@ -22,7 +22,8 @@ class ListQueries {
   Future<int> createList(String name) async {
     if (_database != null) {
       try {
-        await _database?.insert(listsTable, KanjiList(name: name, lastUpdated: GeneralUtils.getCurrentMilliseconds()).toJson());
+        await _database?.insert(KanListTableFields.listsTable,
+            KanjiList(name: name, lastUpdated: GeneralUtils.getCurrentMilliseconds()).toJson());
         return 0;
       } catch (err) {
         print(err.toString());
@@ -33,11 +34,12 @@ class ListQueries {
 
   /// Query to get all [KanjiList] from the db with an optional [order] and [filter].
   /// If anything goes wrong, an empty list will be returned.
-  Future<List<KanjiList>> getAllLists({String filter = lastUpdatedField, String order = "DESC"}) async {
+  Future<List<KanjiList>> getAllLists({String filter = KanListTableFields.lastUpdatedField,
+    String order = "DESC"}) async {
     if (_database != null) {
       try {
         List<Map<String, dynamic>>? res = [];
-        res = await _database?.rawQuery("SELECT * FROM $listsTable ORDER BY $filter $order");
+        res = await _database?.rawQuery("SELECT * FROM ${KanListTableFields.listsTable} ORDER BY $filter $order");
         if (res != null) return List.generate(res.length, (i) => KanjiList.fromJson(res![i]));
         else return [];
       } catch (err) {
@@ -55,12 +57,16 @@ class ListQueries {
       try {
         List<Map<String, dynamic>>? res = [];
         res = await _database?.rawQuery(
-          "SELECT DISTINCT L.$nameField, L.$totalWinRateWritingField, L.$totalWinRateReadingField, "
-          "L.$totalWinRateRecognitionField, L.$lastUpdatedField FROM $listsTable L JOIN $kanjiTable K "
-          "ON K.$listNameField=L.$nameField "
-          "WHERE L.$nameField LIKE '%$query%' OR K.$meaningField LIKE '%$query%' "
-          "OR K.$kanjiField LIKE '%$query%' OR K.$pronunciationField LIKE '%$query%' "
-          "ORDER BY $lastUpdatedField DESC"
+          "SELECT DISTINCT L.${KanListTableFields.nameField}, "
+          "L.${KanListTableFields.totalWinRateWritingField}, "
+          "L.${KanListTableFields.totalWinRateReadingField}, "
+          "L.${KanListTableFields.totalWinRateRecognitionField}, "
+          "L.${KanListTableFields.lastUpdatedField} "
+          "FROM ${KanListTableFields.listsTable} L JOIN ${KanjiTableFields.kanjiTable} K "
+          "ON K.${KanjiTableFields.listNameField}=L.${KanListTableFields.nameField} "
+          "WHERE L.${KanListTableFields.nameField} LIKE '%$query%' OR K.${KanjiTableFields.meaningField} LIKE '%$query%' "
+          "OR K.${KanjiTableFields.kanjiField} LIKE '%$query%' OR K.${KanjiTableFields.pronunciationField} LIKE '%$query%' "
+          "ORDER BY ${KanListTableFields.lastUpdatedField} DESC"
         );
         if (res != null) return List.generate(res.length, (i) => KanjiList.fromJson(res![i]));
         else return [];
@@ -77,7 +83,8 @@ class ListQueries {
     if (_database != null) {
       try {
         List<Map<String, dynamic>>? res = [];
-        res = await _database?.query(listsTable, where: "$listNameField=?", whereArgs: [name]);
+        res = await _database?.query(KanListTableFields.listsTable,
+            where: "${KanjiTableFields.listNameField}=?", whereArgs: [name]);
         if (res != null) return KanjiList.fromJson(res[0]);
         else return KanjiList.empty;
       } catch (err) {
@@ -98,7 +105,8 @@ class ListQueries {
   Future<int> removeList(String name) async {
     if (_database != null) {
       try {
-        await _database?.delete(listsTable, where: "$listNameField=?", whereArgs: [name]);
+        await _database?.delete(KanListTableFields.listsTable,
+            where: "${KanjiTableFields.listNameField}=?", whereArgs: [name]);
         return 0;
       } catch (err) {
         print(err.toString());
@@ -118,7 +126,8 @@ class ListQueries {
   Future<int> updateList(String name, Map<String, dynamic> fields) async {
     if (_database != null) {
       try {
-        await _database?.update(listsTable, fields, where: "$listNameField=?", whereArgs: [name]);
+        await _database?.update(KanListTableFields.listsTable, fields,
+            where: "${KanjiTableFields.listNameField}=?", whereArgs: [name]);
         return 0;
       } catch (err) {
         print(err.toString());

--- a/lib/core/database/queries/test_queries.dart
+++ b/lib/core/database/queries/test_queries.dart
@@ -22,7 +22,7 @@ class TestQueries {
   Future<int> createTest(double score, int kanji, int mode, String lists) async {
     if (_database != null) {
       try {
-        await _database?.insert(testTable, Test(
+        await _database?.insert(TestTableFields.testTable, Test(
           testScore: score, kanjiInTest: kanji,
           studyMode: mode,
           kanjiLists: lists,
@@ -46,7 +46,7 @@ class TestQueries {
   Future<int> removeTests() async {
     if (_database != null) {
       try {
-        await _database?.delete(testTable);
+        await _database?.delete(TestTableFields.testTable);
         return 0;
       } catch (err) {
         print(err.toString());
@@ -62,7 +62,8 @@ class TestQueries {
     if (_database != null) {
       try {
         List<Map<String, dynamic>>? res = [];
-        res = await _database?.rawQuery("SELECT * FROM $testTable ORDER BY $takenDateField DESC "
+        res = await _database?.rawQuery("SELECT * FROM ${TestTableFields.testTable} "
+            "ORDER BY ${TestTableFields.takenDateField} DESC "
             "LIMIT $limit OFFSET ${offset * limit}");
         if (res != null) return List.generate(res.length, (i) => Test.fromJson(res![i]));
         else return [];

--- a/lib/core/routing/pages.dart
+++ b/lib/core/routing/pages.dart
@@ -1,11 +1,13 @@
-const String kanjiListPage = "/KanjiListPage";
-const String settingsPage = "/settingsPage";
-const String kanjiListDetailsPage = "/KanjiListDetailsPage";
-const String addKanjiPage = "/addKanjiPage";
-const String writingStudyPage = "/writingStudyPage";
-const String readingStudyPage = "/readingStudyPage";
-const String recognitionStudyPage = "/recognitionStudyPage";
-const String loginPage = "/loginPage";
-const String backUpPage = "/backUpPage";
-const String testResultPage = "/testResultPage";
-const String testHistoryPage = "/testHistoryPage";
+class KanPracticePages {
+  static const String kanjiListPage = "/KanjiListPage";
+  static const String settingsPage = "/settingsPage";
+  static const String kanjiListDetailsPage = "/KanjiListDetailsPage";
+  static const String addKanjiPage = "/addKanjiPage";
+  static const String writingStudyPage = "/writingStudyPage";
+  static const String readingStudyPage = "/readingStudyPage";
+  static const String recognitionStudyPage = "/recognitionStudyPage";
+  static const String loginPage = "/loginPage";
+  static const String backUpPage = "/backUpPage";
+  static const String testResultPage = "/testResultPage";
+  static const String testHistoryPage = "/testHistoryPage";
+}

--- a/lib/core/routing/routes.dart
+++ b/lib/core/routing/routes.dart
@@ -20,33 +20,33 @@ import 'package:kanpractice/core/utils/study_modes/mode_arguments.dart';
 /// Router generator in which all pages and their transitions are made.
 Route<dynamic>? onGenerateRoute(RouteSettings settings) {
   switch (settings.name) {
-    case kanjiListPage:
+    case KanPracticePages.kanjiListPage:
       return CupertinoPageRoute(builder: (_) => KanjiLists());
-    case kanjiListDetailsPage:
+    case KanPracticePages.kanjiListDetailsPage:
       KanjiList list = settings.arguments as KanjiList;
       return CupertinoPageRoute(builder: (_) => KanjiListDetails(list: list));
-    case settingsPage:
+    case KanPracticePages.settingsPage:
       return CupertinoPageRoute(builder: (_) => Settings());
-    case addKanjiPage:
+    case KanPracticePages.addKanjiPage:
       AddKanjiArgs args = settings.arguments as AddKanjiArgs;
       return CupertinoPageRoute(builder: (_) => AddKanjiPage(args: args));
-    case writingStudyPage:
+    case KanPracticePages.writingStudyPage:
       ModeArguments args = settings.arguments as ModeArguments;
       return CupertinoPageRoute(builder: (_) => WritingStudy(args: args));
-    case readingStudyPage:
+    case KanPracticePages.readingStudyPage:
       ModeArguments args = settings.arguments as ModeArguments;
       return CupertinoPageRoute(builder: (_) => ReadingStudy(args: args));
-    case recognitionStudyPage:
+    case KanPracticePages.recognitionStudyPage:
       ModeArguments args = settings.arguments as ModeArguments;
       return CupertinoPageRoute(builder: (_) => RecognitionStudy(args: args));
-    case testResultPage:
+    case KanPracticePages.testResultPage:
       TestResultArguments args = settings.arguments as TestResultArguments;
       return CupertinoPageRoute(builder: (_) => TestResult(args: args));
-    case testHistoryPage:
+    case KanPracticePages.testHistoryPage:
       return CupertinoPageRoute(builder: (_) => TestHistory());
-    case loginPage:
+    case KanPracticePages.loginPage:
       return CupertinoPageRoute(builder: (_) => LoginPage());
-    case backUpPage:
+    case KanPracticePages.backUpPage:
       String args = settings.arguments as String;
       return CupertinoPageRoute(builder: (_) => BackUpPage(uid: args));
   }

--- a/lib/core/utils/study_modes/study_mode_update_handler.dart
+++ b/lib/core/utils/study_modes/study_mode_update_handler.dart
@@ -47,7 +47,7 @@ class StudyModeUpdateHandler {
             /// and go to the test page.
             else if (isTestFinished) {
               Navigator.of(context).pop(); /// Dialog pop for proper functioning of next navigator call
-              Navigator.of(context).pushReplacementNamed(testResultPage, arguments:
+              Navigator.of(context).pushReplacementNamed(KanPracticePages.testResultPage, arguments:
                 TestResultArguments(score: testScore, kanji: args.studyList.length,
                     studyMode: args.mode.map, listsName: args.listsNames)
               );
@@ -89,17 +89,17 @@ class StudyModeUpdateHandler {
       case StudyModes.writing:
         if (args.studyList[index].winRateWriting == -1) actualScore = score;
         else actualScore =  (score + args.studyList[index].winRateWriting) / 2;
-        toUpdate = { winRateWritingField: actualScore };
+        toUpdate = { KanjiTableFields.winRateWritingField: actualScore };
         break;
       case StudyModes.reading:
         if (args.studyList[index].winRateReading == -1) actualScore = score;
         else actualScore =  (score + args.studyList[index].winRateReading) / 2;
-        toUpdate = { winRateReadingField: actualScore };
+        toUpdate = { KanjiTableFields.winRateReadingField: actualScore };
         break;
       case StudyModes.recognition:
         if (args.studyList[index].winRateRecognition == -1) actualScore = score;
         else actualScore =  (score + args.studyList[index].winRateRecognition) / 2;
-        toUpdate = { winRateRecognitionField: actualScore };
+        toUpdate = { KanjiTableFields.winRateRecognitionField: actualScore };
         break;
     }
     return await KanjiQueries.instance.updateKanji(args.studyList[index].listName,
@@ -144,17 +144,17 @@ class StudyModeUpdateHandler {
       case StudyModes.writing:
         if (list.totalWinRateWriting == -1) actualOverall = overall;
         else actualOverall = (overall + list.totalWinRateWriting) / 2;
-        toUpdate = { totalWinRateWritingField: actualOverall };
+        toUpdate = { KanListTableFields.totalWinRateWritingField: actualOverall };
         break;
       case StudyModes.reading:
         if (list.totalWinRateReading == -1) actualOverall = overall;
         else actualOverall = (overall + list.totalWinRateReading) / 2;
-        toUpdate = { totalWinRateReadingField: actualOverall };
+        toUpdate = { KanListTableFields.totalWinRateReadingField: actualOverall };
         break;
       case StudyModes.recognition:
         if (list.totalWinRateRecognition == -1) actualOverall = overall;
         else actualOverall = (overall + list.totalWinRateRecognition) / 2;
-        toUpdate = { totalWinRateRecognitionField: actualOverall };
+        toUpdate = { KanListTableFields.totalWinRateRecognitionField: actualOverall };
         break;
     }
     await ListQueries.instance.updateList(args.studyList[0].listName, toUpdate);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,7 +67,7 @@ class _KanPracticeState extends State<KanPractice> {
       theme: ThemeManager.instance.currentLightThemeData,
       darkTheme: ThemeManager.instance.currentDarkThemeData,
       themeMode: ThemeManager.instance.themeMode,
-      initialRoute: kanjiListPage,
+      initialRoute: KanPracticePages.kanjiListPage,
       onGenerateRoute: onGenerateRoute,
     );
   }

--- a/lib/ui/pages/add_kanji/add_kanji.dart
+++ b/lib/ui/pages/add_kanji/add_kanji.dart
@@ -104,7 +104,7 @@ class _AddKanjiPageState extends State<AddKanjiPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        toolbarHeight: appBarHeight,
+        toolbarHeight: CustomSizes.appBarHeight,
         title: FittedBox(fit: BoxFit.fitWidth, child: Text(widget.args.kanji != null
             ? "add_kanji_update_title".tr()
             : "add_kanji_new_title".tr(), overflow: TextOverflow.ellipsis

--- a/lib/ui/pages/backup/backup.dart
+++ b/lib/ui/pages/backup/backup.dart
@@ -16,7 +16,7 @@ class BackUpPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        toolbarHeight: appBarHeight,
+        toolbarHeight: CustomSizes.appBarHeight,
         title: FittedBox(fit: BoxFit.fitWidth, child: Text("backup_title".tr())),
       ),
       body: BlocProvider(
@@ -50,7 +50,7 @@ class BackUpPage extends StatelessWidget {
                     Visibility(
                       visible: state.message != "",
                       child: ListTile(
-                        leading: Icon(Icons.info_rounded, color: secondaryColor),
+                        leading: Icon(Icons.info_rounded, color: CustomColors.secondaryColor),
                         title: Text(state.message)
                       ),
                     )

--- a/lib/ui/pages/firebase_login/login.dart
+++ b/lib/ui/pages/firebase_login/login.dart
@@ -158,7 +158,7 @@ class _LoginPageState extends State<LoginPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        toolbarHeight: appBarHeight,
+        toolbarHeight: CustomSizes.appBarHeight,
         title: BlocProvider(
             create: (_) => _bloc..add(LoginIdle()),
             child: BlocBuilder<LoginBloc, LoginState>(
@@ -209,7 +209,7 @@ class _LoginPageState extends State<LoginPage> {
       padding: EdgeInsets.only(right: 16, left: 16),
       child: Column(
         children: [
-          Icon(Icons.info_outline_rounded, color: secondaryColor),
+          Icon(Icons.info_outline_rounded, color: CustomColors.secondaryColor),
           Padding(
             padding: EdgeInsets.only(top: 16, bottom: 16),
             child: Text("login_formDisclaimer".tr()),
@@ -240,7 +240,7 @@ class _LoginPageState extends State<LoginPage> {
             child: Padding(
               padding: EdgeInsets.all(16),
               child: Text("${"login_authentication_failed".tr()} ${state.error}",
-                  style: TextStyle(color: secondaryColor)),
+                  style: TextStyle(color: CustomColors.secondaryColor)),
             ),
           ),
           Padding(
@@ -271,17 +271,17 @@ class _LoginPageState extends State<LoginPage> {
     return Center(
       child: Column(
         children: [
-          Icon(Icons.check_circle_rounded, color: secondaryColor, size: 256),
+          Icon(Icons.check_circle_rounded, color: CustomColors.secondaryColor, size: 256),
           Padding(
             padding: EdgeInsets.all(16),
             child: Text("${"login_current_account_logged".tr()} ${state.user.email}.", textAlign: TextAlign.center),
           ),
           Container(
-            height: appBarHeight,
+            height: CustomSizes.appBarHeight,
             child: Padding(
               padding: EdgeInsets.all(16),
               child: ElevatedButton(
-                onPressed: () => Navigator.of(context).pushNamed(backUpPage, arguments: state.user.uid),
+                onPressed: () => Navigator.of(context).pushNamed(KanPracticePages.backUpPage, arguments: state.user.uid),
                 child: Text("login_manage_backup_title".tr()),
               ),
             ),
@@ -327,7 +327,7 @@ class _LoginPageState extends State<LoginPage> {
     return Center(
       child: Column(
         children: [
-          Icon(Icons.check_circle_rounded, color: secondaryColor, size: 256),
+          Icon(Icons.check_circle_rounded, color: CustomColors.secondaryColor, size: 256),
           Padding(
             padding: EdgeInsets.all(16),
             child: Text(state.message, textAlign: TextAlign.center),

--- a/lib/ui/pages/kanji_list_details/bloc/details_bloc.dart
+++ b/lib/ui/pages/kanji_list_details/bloc/details_bloc.dart
@@ -31,7 +31,7 @@ class KanjiListDetailBloc extends Bloc<KanjiListDetailEvent, KanjiListDetailStat
   Stream<KanjiListDetailState> _mapUpdateNameToState(UpdateKanList event) async* {
     yield KanjiListDetailStateLoading();
     final error = await ListQueries.instance.updateList(event.og, {
-      nameField: event.name
+      KanListTableFields.nameField: event.name
     });
     if (error == 0) {
       final lists = await KanjiQueries.instance.getAllKanjiFromList(event.name);

--- a/lib/ui/pages/kanji_list_details/list_details.dart
+++ b/lib/ui/pages/kanji_list_details/list_details.dart
@@ -84,17 +84,17 @@ class _KanjiListDetailsState extends State<KanjiListDetails> {
 
       switch (_selectedMode) {
         case StudyModes.writing:
-          await Navigator.of(context).pushNamed(writingStudyPage,
+          await Navigator.of(context).pushNamed(KanPracticePages.writingStudyPage,
               arguments: ModeArguments(studyList: list, isTest: false, mode: StudyModes.writing))
               .then((value) => _bloc..add(KanjiEventLoading(_listName)));
           break;
         case StudyModes.reading:
-          await Navigator.of(context).pushNamed(readingStudyPage,
+          await Navigator.of(context).pushNamed(KanPracticePages.readingStudyPage,
               arguments: ModeArguments(studyList: list, isTest: false, mode: StudyModes.reading))
               .then((value) => _bloc..add(KanjiEventLoading(_listName)));
           break;
         case StudyModes.recognition:
-          await Navigator.of(context).pushNamed(recognitionStudyPage,
+          await Navigator.of(context).pushNamed(KanPracticePages.recognitionStudyPage,
               arguments: ModeArguments(studyList: list, isTest: false, mode: StudyModes.recognition))
               .then((value) => _bloc..add(KanjiEventLoading(_listName)));
           break;
@@ -179,16 +179,16 @@ class _KanjiListDetailsState extends State<KanjiListDetails> {
       onWillPop: () async {
         if ((_bloc.state as KanjiListDetailStateLoaded).list.length == 0) {
           await ListQueries.instance.updateList(_listName, {
-            totalWinRateWritingField: -1,
-            totalWinRateReadingField: -1,
-            totalWinRateRecognitionField: -1
+            KanListTableFields.totalWinRateWritingField: -1,
+            KanListTableFields.totalWinRateReadingField: -1,
+            KanListTableFields.totalWinRateRecognitionField: -1
           });
         }
         return true;
       },
       child: Scaffold(
         appBar: AppBar(
-          toolbarHeight: appBarHeight,
+          toolbarHeight: CustomSizes.appBarHeight,
           title: BlocProvider(
             create: (_) => _bloc..add(KanjiEventLoading(_listName)),
             child: BlocBuilder<KanjiListDetailBloc, KanjiListDetailState>(
@@ -225,7 +225,7 @@ class _KanjiListDetailsState extends State<KanjiListDetails> {
             ),
             IconButton(
               onPressed: () async {
-                await Navigator.of(context).pushNamed(addKanjiPage,
+                await Navigator.of(context).pushNamed(KanPracticePages.addKanjiPage,
                     arguments: AddKanjiArgs(listName: _listName))
                     .then((code) {
                   _bloc..add(KanjiEventLoading(_listName));
@@ -337,7 +337,7 @@ class _KanjiListDetailsState extends State<KanjiListDetails> {
           listName: _listName,
           selectedMode: _selectedMode,
           onTap: () async {
-            await Navigator.of(context).pushNamed(addKanjiPage,
+            await Navigator.of(context).pushNamed(KanPracticePages.addKanjiPage,
                 arguments: AddKanjiArgs(listName: _listName, kanji: kanji))
                 .then((code) {
               if (code == 0) _bloc..add(KanjiEventLoading(_listName));

--- a/lib/ui/pages/kanji_list_details/widgets/KanjiBottomSheet.dart
+++ b/lib/ui/pages/kanji_list_details/widgets/KanjiBottomSheet.dart
@@ -131,7 +131,7 @@ class KanjiBottomSheet extends StatelessWidget {
 
   Container _actionButtons(BuildContext context) {
     return Container(
-      height: actionButtonsKanjiDetail,
+      height: CustomSizes.actionButtonsKanjiDetail,
       child: Column(
         children: [
           ListTile(

--- a/lib/ui/pages/kanji_lists/filters.dart
+++ b/lib/ui/pages/kanji_lists/filters.dart
@@ -20,14 +20,14 @@ extension KanListFiltersExtensions on KanListFilters {
   String get filter {
     switch (this) {
       case KanListFilters.writing:
-        return totalWinRateWritingField;
+        return KanListTableFields.totalWinRateWritingField;
       case KanListFilters.reading:
-        return totalWinRateReadingField;
+        return KanListTableFields.totalWinRateReadingField;
       case KanListFilters.recognition:
-        return totalWinRateRecognitionField;
+        return KanListTableFields.totalWinRateRecognitionField;
       case KanListFilters.all:
       default:
-        return lastUpdatedField;
+        return KanListTableFields.lastUpdatedField;
     }
   }
 }

--- a/lib/ui/pages/kanji_lists/kanji_lists.dart
+++ b/lib/ui/pages/kanji_lists/kanji_lists.dart
@@ -33,13 +33,13 @@ class _KanjiListsState extends State<KanjiLists> {
   /// This variable keeps track of the actual filter applied. The value is
   /// saved into the shared preferences when a filter is applied.
   /// This value is then restored upon new session.
-  String _currentAppliedFilter = lastUpdatedField;
+  String _currentAppliedFilter = KanListTableFields.lastUpdatedField;
   /// State map for the filters, independent of the bloc.
   Map<String, bool> _filterValues = {
-    lastUpdatedField: true,
-    totalWinRateWritingField: false,
-    totalWinRateReadingField: false,
-    totalWinRateRecognitionField: false
+    KanListTableFields.lastUpdatedField: true,
+    KanListTableFields.totalWinRateWritingField: false,
+    KanListTableFields.totalWinRateReadingField: false,
+    KanListTableFields.totalWinRateRecognitionField: false
   };
 
   /// This variable keeps track of the order applied on the current filter only:
@@ -54,7 +54,7 @@ class _KanjiListsState extends State<KanjiLists> {
   void initState() {
     _searchBarFn = FocusNode();
     _searchBarFn?.addListener(_focusListener);
-    _currentAppliedFilter = StorageManager.readData(StorageManager.filtersOnList) ?? lastUpdatedField;
+    _currentAppliedFilter = StorageManager.readData(StorageManager.filtersOnList) ?? KanListTableFields.lastUpdatedField;
     _currentAppliedOrder = StorageManager.readData(StorageManager.orderOnList) ?? true;
     _getVersionNotice();
     super.initState();
@@ -83,7 +83,7 @@ class _KanjiListsState extends State<KanjiLists> {
       builder: (context) => CustomDialog(
         title: Text("kanji_lists_createDialogForAddingKanList_title".tr()),
         content: Container(
-          height: alertDialogHeight,
+          height: CustomSizes.alertDialogHeight,
           child: CustomTextForm(
             header: "kanji_lists_createDialogForAddingKanList_header".tr(),
             controller: controller,
@@ -165,7 +165,7 @@ class _KanjiListsState extends State<KanjiLists> {
       },
       child: Scaffold(
         appBar: AppBar(
-          toolbarHeight: appBarHeight,
+          toolbarHeight: CustomSizes.appBarHeight,
           title: FittedBox(fit: BoxFit.fitWidth, child: Text("KanPractice")),
           actions: [
             IconButton(
@@ -182,7 +182,7 @@ class _KanjiListsState extends State<KanjiLists> {
             ),
             IconButton(
               onPressed: () async {
-                await Navigator.of(context).pushNamed(settingsPage).then((code) {
+                await Navigator.of(context).pushNamed(KanPracticePages.settingsPage).then((code) {
                   _addLoadingEvent();
                 });
               },
@@ -288,7 +288,7 @@ class _KanjiListsState extends State<KanjiLists> {
       child: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(18),
-          color: secondaryColor
+          color: CustomColors.secondaryColor
         ),
         padding: EdgeInsets.symmetric(vertical: 8),
         margin: EdgeInsets.only(bottom: 8, right: 32, left: 32),

--- a/lib/ui/pages/kanji_lists/widgets/KanListTile.dart
+++ b/lib/ui/pages/kanji_lists/widgets/KanListTile.dart
@@ -25,7 +25,7 @@ class KanListTile extends StatelessWidget {
     return ListTile(
       onTap: () async {
         onTap();
-        await Navigator.of(context).pushNamed(kanjiListDetailsPage, arguments: item)
+        await Navigator.of(context).pushNamed(KanPracticePages.kanjiListDetailsPage, arguments: item)
             .then((_) => onPopWhenTapped());
       },
       onLongPress: () => _createDialogForDeletingKanList(context, item),

--- a/lib/ui/pages/kanji_lists/widgets/StudyBottomSheet.dart
+++ b/lib/ui/pages/kanji_lists/widgets/StudyBottomSheet.dart
@@ -68,7 +68,7 @@ class _StudyBottomSheetState extends State<StudyBottomSheet> {
                   visible: !_selectionMode,
                   child: BlocProvider(
                     create: (_) => KanjiListBloc()..add(KanjiListEventLoading(
-                        filter: lastUpdatedField, order: false
+                        filter: KanListTableFields.lastUpdatedField, order: false
                     )),
                     child: BlocBuilder<KanjiListBloc, KanjiListState>(
                       builder: (context, state) {
@@ -78,7 +78,7 @@ class _StudyBottomSheetState extends State<StudyBottomSheet> {
                           return CustomProgressIndicator();
                         else if (state is KanjiListStateLoaded) {
                           return Container(
-                            constraints: BoxConstraints(maxHeight: maxHeightForListsTest),
+                            constraints: BoxConstraints(maxHeight: CustomSizes.maxHeightForListsTest),
                             margin: EdgeInsets.all(8),
                             child: _listSelection(state)
                           );
@@ -108,7 +108,7 @@ class _StudyBottomSheetState extends State<StudyBottomSheet> {
                 padding: EdgeInsets.only(right: 8),
                 child: ActionChip(
                   label: Text(name),
-                  backgroundColor: _selectedLists.contains(name) ? secondaryColor : secondarySubtleColor,
+                  backgroundColor: _selectedLists.contains(name) ? CustomColors.secondaryColor : CustomColors.secondarySubtleColor,
                   onPressed: () {
                     setState(() {
                       if (_selectedLists.contains(name)) _selectedLists.remove(name);

--- a/lib/ui/pages/reading/reading.dart
+++ b/lib/ui/pages/reading/reading.dart
@@ -97,7 +97,7 @@ class _ReadingStudyState extends State<ReadingStudy> {
       onWillPop: () async => StudyModeUpdateHandler.handle(context, widget.args, onPop: true, lastIndex: _macro),
       child: Scaffold(
         appBar: AppBar(
-          toolbarHeight: appBarHeight,
+          toolbarHeight: CustomSizes.appBarHeight,
           title: FittedBox(fit: BoxFit.fitWidth, child: Text(widget.args.mode.mode)),
           centerTitle: true
         ),
@@ -108,10 +108,10 @@ class _ReadingStudyState extends State<ReadingStudy> {
           child: Column(
             children: [
               ListPercentageIndicator(value: (_macro + 1) / _studyList.length),
-              Text(_getProperAlphabet(), style: TextStyle(fontSize: 24, color: secondaryColor)),
+              Text(_getProperAlphabet(), style: TextStyle(fontSize: 24, color: CustomColors.secondarySubtleColor)),
               Text(_getProperPronunciation(), style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold)),
               Container(
-                height: listStudyHeight,
+                height: CustomSizes.listStudyHeight,
                 child: FittedBox(
                   fit: BoxFit.contain,
                   child: Text(_studyList[_macro].kanji, style: TextStyle(fontSize: 64)),

--- a/lib/ui/pages/recognition/recognition.dart
+++ b/lib/ui/pages/recognition/recognition.dart
@@ -86,7 +86,7 @@ class _RecognitionStudyState extends State<RecognitionStudy> {
       onWillPop: () async => StudyModeUpdateHandler.handle(context, widget.args, onPop: true, lastIndex: _macro),
       child: Scaffold(
         appBar: AppBar(
-          toolbarHeight: appBarHeight,
+          toolbarHeight: CustomSizes.appBarHeight,
           title: FittedBox(fit: BoxFit.fitWidth, child: Text(widget.args.mode.mode)),
           centerTitle: true
         ),
@@ -99,7 +99,7 @@ class _RecognitionStudyState extends State<RecognitionStudy> {
               ListPercentageIndicator(value: (_macro + 1) / _studyList.length),
               Text(_getProperPronunciation()),
               Container(
-                height: listStudyHeight,
+                height: CustomSizes.listStudyHeight,
                 child: FittedBox(
                   fit: BoxFit.contain,
                   child: Text(_studyList[_macro].kanji, style: TextStyle(fontSize: 64)),

--- a/lib/ui/pages/settings/settings.dart
+++ b/lib/ui/pages/settings/settings.dart
@@ -32,7 +32,7 @@ class _SettingsState extends State<Settings> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        toolbarHeight: appBarHeight,
+        toolbarHeight: CustomSizes.appBarHeight,
         automaticallyImplyLeading: false,
         leading: IconButton(
           icon: Icon(Icons.arrow_back_ios_rounded),
@@ -63,7 +63,7 @@ class _SettingsState extends State<Settings> {
           ListTile(
             leading: Icon(Icons.track_changes_rounded),
             title: Text("settings_progress_testHistory".tr()),
-            onTap: () async => Navigator.of(context).pushNamed(testHistoryPage),
+            onTap: () async => Navigator.of(context).pushNamed(KanPracticePages.testHistoryPage),
           ),
           BlocProvider(
             create: (_) => _settingsBloc..add(SettingsLoadingBackUpDate(context)),
@@ -83,7 +83,7 @@ class _SettingsState extends State<Settings> {
           ListTile(
             leading: Icon(Icons.whatshot_rounded),
             title: Text("settings_account_label".tr()),
-            onTap: () => Navigator.of(context).pushNamed(loginPage)
+            onTap: () => Navigator.of(context).pushNamed(KanPracticePages.loginPage)
           ),
           _header("settings_information_section".tr()),
           Divider(),

--- a/lib/ui/pages/test_history/test_history.dart
+++ b/lib/ui/pages/test_history/test_history.dart
@@ -37,7 +37,7 @@ class _TestHistoryState extends State<TestHistory> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        toolbarHeight: appBarHeight,
+        toolbarHeight: CustomSizes.appBarHeight,
         title: FittedBox(fit: BoxFit.fitWidth, child: Text("test_history_title".tr())),
         actions: [
           IconButton(
@@ -73,7 +73,7 @@ class _TestHistoryState extends State<TestHistory> {
       itemCount: state.list.length,
       itemBuilder: (context, k) {
         Test t = state.list[k];
-        Color chartColor = secondaryColor;
+        Color chartColor = CustomColors.secondaryColor;
         StudyModes mode = StudyModesUtil.mapStudyMode(t.studyMode);
 
         if (mode == StudyModes.writing) chartColor = StudyModes.writing.color;

--- a/lib/ui/pages/test_result/test_result.dart
+++ b/lib/ui/pages/test_result/test_result.dart
@@ -17,7 +17,7 @@ class TestResult extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(
           automaticallyImplyLeading: false,
-          toolbarHeight: appBarHeight,
+          toolbarHeight: CustomSizes.appBarHeight,
         ),
         body: SingleChildScrollView(
           child: Column(

--- a/lib/ui/pages/writing/writing.dart
+++ b/lib/ui/pages/writing/writing.dart
@@ -144,7 +144,7 @@ class _WritingStudyState extends State<WritingStudy> {
       onWillPop: () async => StudyModeUpdateHandler.handle(context, widget.args, onPop: true, lastIndex: _macro),
       child: Scaffold(
         appBar: AppBar(
-          toolbarHeight: appBarHeight,
+          toolbarHeight: CustomSizes.appBarHeight,
           title: FittedBox(fit: BoxFit.fitWidth, child: Text(widget.args.mode.mode)),
           centerTitle: true,
           actions: [
@@ -174,9 +174,11 @@ class _WritingStudyState extends State<WritingStudy> {
   }
 
   Container _header() {
-    double finalHeight = MediaQuery.of(context).size.height < 700 ? listStudyHeight / 2 : listStudyHeight;
+    double finalHeight = MediaQuery.of(context).size.height < 700
+        ? CustomSizes.listStudyHeight / 2 : CustomSizes.listStudyHeight;
     return Container(
-      height: MediaQuery.of(context).size.height < 700 ? studyGuideHeight / 2 : studyGuideHeight,
+      height: MediaQuery.of(context).size.height < 700
+          ? CustomSizes.studyGuideHeight / 2 : CustomSizes.studyGuideHeight,
       padding: EdgeInsets.symmetric(horizontal: 8),
       child: Column(
         children: [
@@ -200,7 +202,7 @@ class _WritingStudyState extends State<WritingStudy> {
                     return Text(_currentKanji[_macro][index] == _none ? _none : kanji[index],
                       style: TextStyle(fontSize:
                           MediaQuery.of(context).size.height < 700 ? 32 : 64,
-                          color: index == _inner ? secondaryColor : null)
+                          color: index == _inner ? CustomColors.secondaryColor : null)
                     );
                   },
                 ),

--- a/lib/ui/theme/dark.dart
+++ b/lib/ui/theme/dark.dart
@@ -43,7 +43,7 @@ final ThemeData dark = ThemeData(
     ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.all<Color>(secondaryColor),
+        backgroundColor: MaterialStateProperty.all<Color>(CustomColors.secondaryColor),
         shape: MaterialStateProperty.all<OutlinedBorder>(RoundedRectangleBorder(borderRadius: BorderRadius.circular(8))),
       ),
     ),
@@ -58,7 +58,7 @@ final ThemeData dark = ThemeData(
         contentTextStyle: TextStyle(color: _primary)
     ),
     textSelectionTheme: TextSelectionThemeData(
-        cursorColor: secondaryColor
+        cursorColor: CustomColors.secondaryColor
     ),
     inputDecorationTheme: InputDecorationTheme(
         hintStyle: TextStyle(color: Colors.grey[400]),
@@ -68,7 +68,7 @@ final ThemeData dark = ThemeData(
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.all(Radius.circular(24)),
-          borderSide: BorderSide(color: secondaryColor, width: 2.0),
+          borderSide: BorderSide(color: CustomColors.secondaryColor, width: 2.0),
         )
     ),
     bottomSheetTheme: BottomSheetThemeData(
@@ -82,7 +82,7 @@ final ThemeData dark = ThemeData(
     ),
     dialogBackgroundColor: _primary,
     chipTheme: ChipThemeData(
-        selectedColor: secondaryColor,
+        selectedColor: CustomColors.secondaryColor,
         secondaryLabelStyle: TextStyle(color: Colors.black),
         brightness: Brightness.dark,
         backgroundColor: _chipColor,

--- a/lib/ui/theme/light.dart
+++ b/lib/ui/theme/light.dart
@@ -43,7 +43,7 @@ final ThemeData light = ThemeData(
     ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.all<Color>(secondaryColor),
+        backgroundColor: MaterialStateProperty.all<Color>(CustomColors.secondaryColor),
         shape: MaterialStateProperty.all<OutlinedBorder>(RoundedRectangleBorder(borderRadius: BorderRadius.circular(8))),
       ),
     ),
@@ -58,7 +58,7 @@ final ThemeData light = ThemeData(
         contentTextStyle: TextStyle(color: _accent)
     ),
     textSelectionTheme: TextSelectionThemeData(
-        cursorColor: secondaryColor
+        cursorColor: CustomColors.secondaryColor
     ),
     inputDecorationTheme: InputDecorationTheme(
         hintStyle: TextStyle(color: Colors.grey[400]),
@@ -68,7 +68,7 @@ final ThemeData light = ThemeData(
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.all(Radius.circular(24)),
-          borderSide: BorderSide(color: secondaryColor, width: 2.0),
+          borderSide: BorderSide(color: CustomColors.secondaryColor, width: 2.0),
         )
     ),
     bottomSheetTheme: BottomSheetThemeData(
@@ -82,7 +82,7 @@ final ThemeData light = ThemeData(
     ),
     dialogBackgroundColor: _primary,
     chipTheme: ChipThemeData(
-        selectedColor: secondaryColor,
+        selectedColor: CustomColors.secondaryColor,
         secondaryLabelStyle: TextStyle(color: _primary),
         brightness: Brightness.light,
         backgroundColor: _chipColor,

--- a/lib/ui/theme/theme_consts.dart
+++ b/lib/ui/theme/theme_consts.dart
@@ -1,26 +1,20 @@
 import 'package:flutter/material.dart';
 
-const double defaultSizeSearchBarIcons = 50;
-const double appBarHeight = 80;
-const double listStudyHeight = 85;
-const double customButtonHeight = 90;
-const double alertDialogHeight = 100;
-const double customButtonWidth = 110;
-const double studyGuideHeight = listStudyHeight + 44;
-const double actionButtonsKanjiDetail = 130;
-const double maxHeightForListsTest = 240;
+class CustomSizes {
+  static const double defaultSizeSearchBarIcons = 50;
+  static const double appBarHeight = 80;
+  static const double listStudyHeight = 85;
+  static const double customButtonHeight = 90;
+  static const double alertDialogHeight = 100;
+  static const double customButtonWidth = 110;
+  static const double studyGuideHeight = listStudyHeight + 44;
+  static const double actionButtonsKanjiDetail = 130;
+  static const double maxHeightForListsTest = 240;
 
-const int numberOfKanjiInTest = 30;
+  static const int numberOfKanjiInTest = 30;
+}
 
-const Color secondaryColor = Color(0xFFD32F2F);
-const Color secondarySubtleColor = Color(0xFFE57373);
-
-final ButtonStyle correctButton = ButtonStyle(
-  backgroundColor: MaterialStateProperty.all<Color>(Colors.green),
-  shape: MaterialStateProperty.all<OutlinedBorder>(RoundedRectangleBorder(borderRadius: BorderRadius.circular(8))),
-);
-
-final ButtonStyle wrongButton = ButtonStyle(
-  backgroundColor: MaterialStateProperty.all<Color>(Colors.grey),
-  shape: MaterialStateProperty.all<OutlinedBorder>(RoundedRectangleBorder(borderRadius: BorderRadius.circular(8))),
-);
+class CustomColors {
+  static const Color secondaryColor = Color(0xFFD32F2F);
+  static const Color secondarySubtleColor = Color(0xFFE57373);
+}

--- a/lib/ui/widgets/BlitzBottomSheet.dart
+++ b/lib/ui/widgets/BlitzBottomSheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kanpractice/core/database/database_consts.dart';
 import 'package:kanpractice/core/database/models/kanji.dart';
 import 'package:kanpractice/core/database/queries/kanji_queries.dart';
 import 'package:kanpractice/ui/widgets/StudyMode.dart';
@@ -27,16 +28,16 @@ class BlitzBottomSheet extends StatelessWidget {
     if (listName == null) {
       List<Kanji> list = await KanjiQueries.instance.getAllKanji();
       list.shuffle();
-      return list.sublist(0, list.length < numberOfKanjiInTest
-          ? list.length : numberOfKanjiInTest);
+      return list.sublist(0, list.length < CustomSizes.numberOfKanjiInTest
+          ? list.length : CustomSizes.numberOfKanjiInTest);
     }
     /// If the listName is not empty, it means that the user wants to have
     /// a Blitz Test on a certain KanList defined in "listName"
     else {
       List<Kanji> list = await KanjiQueries.instance.getAllKanjiFromList(listName);
       list.shuffle();
-      return list.sublist(0, list.length < numberOfKanjiInTest
-          ? list.length : numberOfKanjiInTest);
+      return list.sublist(0, list.length < CustomSizes.numberOfKanjiInTest
+          ? list.length : CustomSizes.numberOfKanjiInTest);
     }
   }
 
@@ -59,7 +60,7 @@ class BlitzBottomSheet extends StatelessWidget {
                 ),
                 Padding(
                   padding: EdgeInsets.symmetric(vertical: 8, horizontal: 32),
-                  child: Text("${numberOfKanjiInTest.toString()} ${"blitz_bottom_sheet_content".tr()}",
+                  child: Text("${CustomSizes.numberOfKanjiInTest.toString()} ${"blitz_bottom_sheet_content".tr()}",
                       textAlign: TextAlign.center,
                       style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
                 ),

--- a/lib/ui/widgets/CustomAlertDialog.dart
+++ b/lib/ui/widgets/CustomAlertDialog.dart
@@ -21,7 +21,7 @@ class CustomDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: alertDialogHeight,
+      height: CustomSizes.alertDialogHeight,
       child: AlertDialog(
         title: title,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(18))),
@@ -31,13 +31,19 @@ class CustomDialog extends StatelessWidget {
             visible: negativeButton,
             child: ElevatedButton(
               child: Text("back_button_label".tr()),
-              style: wrongButton,
+              style: ButtonStyle(
+                backgroundColor: MaterialStateProperty.all<Color>(Colors.grey),
+                shape: MaterialStateProperty.all<OutlinedBorder>(RoundedRectangleBorder(borderRadius: BorderRadius.circular(8))),
+              ),
               onPressed: () => Navigator.of(context).pop()
             ),
           ),
           ElevatedButton(
             child: Text(positiveButtonText),
-            style: correctButton,
+            style: ButtonStyle(
+              backgroundColor: MaterialStateProperty.all<Color>(Colors.green),
+              shape: MaterialStateProperty.all<OutlinedBorder>(RoundedRectangleBorder(borderRadius: BorderRadius.circular(8))),
+            ),
             onPressed: () async {
               await onPositive();
               if (popDialog) Navigator.of(context).pop();

--- a/lib/ui/widgets/CustomButton.dart
+++ b/lib/ui/widgets/CustomButton.dart
@@ -12,7 +12,8 @@ class CustomButton extends StatelessWidget {
   final String title2;
   /// Action to perform when tapping the button
   final Function onTap;
-  const CustomButton({this.width = customButtonWidth, this.color = secondaryColor,
+  const CustomButton({this.width = CustomSizes.customButtonWidth,
+    this.color = CustomColors.secondaryColor,
     required this.title1, required this.title2, required this.onTap
   });
 
@@ -20,7 +21,7 @@ class CustomButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: width,
-      height: customButtonHeight,
+      height: CustomSizes.customButtonHeight,
       alignment: Alignment.center,
       margin: EdgeInsets.all(8),
       decoration: BoxDecoration(
@@ -34,7 +35,7 @@ class CustomButton extends StatelessWidget {
           borderRadius: BorderRadius.circular(18),
           child: Container(
             width: width,
-            height: customButtonHeight,
+            height: CustomSizes.customButtonHeight,
             alignment: Alignment.center,
             margin: EdgeInsets.all(8),
             decoration: BoxDecoration(borderRadius: BorderRadius.circular(18)),

--- a/lib/ui/widgets/CustomSearchBar.dart
+++ b/lib/ui/widgets/CustomSearchBar.dart
@@ -112,8 +112,8 @@ class _CustomSearchBarState extends State<CustomSearchBar> {
 
   Container _back() {
     return Container(
-      width: defaultSizeSearchBarIcons,
-      height: defaultSizeSearchBarIcons,
+      width: CustomSizes.defaultSizeSearchBarIcons,
+      height: CustomSizes.defaultSizeSearchBarIcons,
       child: InkWell(
         borderRadius: BorderRadius.circular(32),
         onTap: () {
@@ -133,8 +133,8 @@ class _CustomSearchBarState extends State<CustomSearchBar> {
 
   Container _clear() {
     return Container(
-      width: defaultSizeSearchBarIcons,
-      height: defaultSizeSearchBarIcons,
+      width: CustomSizes.defaultSizeSearchBarIcons,
+      height: CustomSizes.defaultSizeSearchBarIcons,
       child: InkWell(
         borderRadius: BorderRadius.circular(32),
         onTap: () {

--- a/lib/ui/widgets/ListPercentageIndicator.dart
+++ b/lib/ui/widgets/ListPercentageIndicator.dart
@@ -14,8 +14,8 @@ class ListPercentageIndicator extends StatelessWidget {
       padding: EdgeInsets.only(bottom: 16, right: 16, left: 16),
       child: LinearPercentIndicator(
         percent: value,
-        backgroundColor: secondarySubtleColor,
-        progressColor: secondaryColor,
+        backgroundColor: CustomColors.secondarySubtleColor,
+        progressColor: CustomColors.secondaryColor,
         lineHeight: 30,
         animation: true,
         animationDuration: 1000,

--- a/lib/ui/widgets/StudyMode.dart
+++ b/lib/ui/widgets/StudyMode.dart
@@ -21,7 +21,7 @@ class TestStudyMode extends StatelessWidget {
       child: Column(
         children: [
           Container(
-            height: customButtonHeight,
+            height: CustomSizes.customButtonHeight,
             child: ListView(
               shrinkWrap: true,
               scrollDirection: Axis.horizontal,
@@ -55,20 +55,20 @@ class TestStudyMode extends StatelessWidget {
         }
         else {
           list.shuffle();
-          List<Kanji> sortedList = list.sublist(0, list.length < numberOfKanjiInTest
-              ? list.length : numberOfKanjiInTest);
+          List<Kanji> sortedList = list.sublist(0, list.length < CustomSizes.numberOfKanjiInTest
+              ? list.length : CustomSizes.numberOfKanjiInTest);
           Navigator.of(context).pop(); // Dismiss bottom sheet
           switch (mode) {
             case StudyModes.writing:
-              await Navigator.of(context).pushNamed(writingStudyPage,
+              await Navigator.of(context).pushNamed(KanPracticePages.writingStudyPage,
                   arguments: ModeArguments(studyList: sortedList, isTest: true, mode: mode, listsNames: listsNames));
               break;
             case StudyModes.reading:
-              await Navigator.of(context).pushNamed(readingStudyPage,
+              await Navigator.of(context).pushNamed(KanPracticePages.readingStudyPage,
                   arguments: ModeArguments(studyList: sortedList, isTest: true, mode: mode, listsNames: listsNames));
               break;
             case StudyModes.recognition:
-              await Navigator.of(context).pushNamed(recognitionStudyPage,
+              await Navigator.of(context).pushNamed(KanPracticePages.recognitionStudyPage,
                   arguments: ModeArguments(studyList: sortedList, isTest: true, mode: mode, listsNames: listsNames));
               break;
           }

--- a/lib/ui/widgets/ValidationButtons.dart
+++ b/lib/ui/widgets/ValidationButtons.dart
@@ -16,7 +16,7 @@ class ValidationButtons extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: listStudyHeight,
+      height: CustomSizes.listStudyHeight,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: [

--- a/lib/ui/widgets/WinRateChart.dart
+++ b/lib/ui/widgets/WinRateChart.dart
@@ -14,7 +14,7 @@ class WinRateChart extends StatelessWidget {
   /// Value of the [winRate] text size
   final double? rateSize;
   const WinRateChart({required this.title, required this.winRate, this.size = 80, this.rateSize,
-    this.chartColor = secondaryColor
+    this.chartColor = CustomColors.secondaryColor
   });
 
   @override


### PR DESCRIPTION
- Changed Kanji PK to Compound with kanji, meaning and pronunciation to be able to save, for example: (木) as tree and [き], and (木) as thursday [木曜日]. Previously, this would result in a violation of the PK as it was only the kanji.
- Refactored the loose constants on the code and grouped them in classes to better localization.